### PR TITLE
Running python programs

### DIFF
--- a/apps/compiler/compilation-environments/python/python.coffee
+++ b/apps/compiler/compilation-environments/python/python.coffee
@@ -1,0 +1,43 @@
+﻿exec = require('child_process').exec
+Path = require 'path'
+
+Config = require_harrogate_module 'config.coffee'
+
+module.exports =
+
+  compile: (project_resource, cb) ->
+    project_resource.src_directory.is_valid()
+
+    .then (valid) ->
+      if not valid
+        throw new ServerError 404, 'Python Project ' + project_resource.name + ' does not contain any source files'
+
+      return project_resource.src_directory.get_children()
+
+    .then (src_files) ->
+      cp_cmd = "cp "
+      pyc_cmd = "python -m py_compile "
+
+      for src in src_files
+        if Path.basename(src.path).charAt(0) isnt '.'
+          cp_cmd += '"' + src.path + "\" "
+          pyc_cmd += "\"#{project_resource.bin_directory.path}/" + src.name + "\" "
+
+      cp_cmd += " \"#{project_resource.bin_directory.path}/\" "
+
+      ln_cmd = "ln -s \"#{project_resource.bin_directory.path}/main.py\" \"#{project_resource.binary.path}\""
+      chmod_cmd = "chmod u+x \"#{project_resource.binary.path}\""
+
+
+      exec cp_cmd
+      exec ln_cmd
+      exec chmod_cmd
+      exec pyc_cmd, cb 
+      return
+
+    .catch (e) ->
+      cb e
+      return
+
+    .done()
+    return

--- a/apps/programs/workspace.coffee
+++ b/apps/programs/workspace.coffee
@@ -200,10 +200,10 @@ class Workspace
 
                   import wallaby
 
-                  def main()
+                  def main():
                     print "Hello World"
 
-                  if __name__=="__main__"
+                  if __name__=="__main__":
                     main()
                   """
         else


### PR DESCRIPTION
This allows python programs to be compiled and run as long as the python compilation environment is selected.  We still need to do that here:
https://github.com/kipr/harrogate/blob/master/apps/compiler/api-routes/compile.coffee#L15

where the following should be used for python projects: 
````javascript
compilation_environment = require '../compilation-environments/python/python.coffee'
````

The current solution requires that the user project includes a ``main.py`` which is the entry point during execution... which is how our project template initializes things.